### PR TITLE
Serialize keybinds as keycodes rather than ints

### DIFF
--- a/Source/DebugMod.cs
+++ b/Source/DebugMod.cs
@@ -61,7 +61,15 @@ namespace DebugMod
         //internal static int NailDamage;
         
         public static GlobalSettings settings { get; set; } = new GlobalSettings();
-        public void OnLoadGlobal(GlobalSettings s) => DebugMod.settings = s;
+        public void OnLoadGlobal(GlobalSettings s)
+        {
+            DebugMod.settings = s;
+            if (settings.binds is null)
+            {
+                settings.binds = new();
+                DebugMod.ResetKeyBinds();
+            }
+        }
         public GlobalSettings OnSaveGlobal() => DebugMod.settings;
         public SaveSettings LocalSaveData { get; set; } = new SaveSettings();
         public void OnLoadLocal(SaveSettings s) => this.LocalSaveData = s;
@@ -252,20 +260,20 @@ namespace DebugMod
         {
             settings.binds.Clear();
 
-            settings.binds.Add("Toggle All UI", (int) KeyCode.F1);
-            settings.binds.Add("Toggle Info", (int) KeyCode.F2);
-            settings.binds.Add("Toggle Menu", (int) KeyCode.F3);
-            settings.binds.Add("Toggle Console", (int) KeyCode.F4);
-            settings.binds.Add("Full/Min Info Switch", (int) KeyCode.F6);
-            settings.binds.Add("Force Camera Follow", (int) KeyCode.F8);
-            settings.binds.Add("Toggle Enemy Panel", (int) KeyCode.F9);
-            settings.binds.Add("Toggle Binds", (int) KeyCode.BackQuote);
-            settings.binds.Add("Nail Damage +4", (int) KeyCode.Equals);
-            settings.binds.Add("Nail Damage -4", (int) KeyCode.Minus);
-            settings.binds.Add("Increase Timescale", (int) KeyCode.KeypadPlus);
-            settings.binds.Add("Decrease Timescale", (int) KeyCode.KeypadMinus);
-            settings.binds.Add("Zoom In", (int) KeyCode.PageUp);
-            settings.binds.Add("Zoom Out", (int) KeyCode.PageDown);
+            settings.binds.Add("Toggle All UI", KeyCode.F1);
+            settings.binds.Add("Toggle Info", KeyCode.F2);
+            settings.binds.Add("Toggle Menu", KeyCode.F3);
+            settings.binds.Add("Toggle Console", KeyCode.F4);
+            settings.binds.Add("Full/Min Info Switch", KeyCode.F6);
+            settings.binds.Add("Force Camera Follow", KeyCode.F8);
+            settings.binds.Add("Toggle Enemy Panel", KeyCode.F9);
+            settings.binds.Add("Toggle Binds", KeyCode.BackQuote);
+            settings.binds.Add("Nail Damage +4", KeyCode.Equals);
+            settings.binds.Add("Nail Damage -4", KeyCode.Minus);
+            settings.binds.Add("Increase Timescale", KeyCode.KeypadPlus);
+            settings.binds.Add("Decrease Timescale", KeyCode.KeypadMinus);
+            settings.binds.Add("Zoom In", KeyCode.PageUp);
+            settings.binds.Add("Zoom Out", KeyCode.PageDown);
         }
         private void SaveSettings()
         {

--- a/Source/GUIController.cs
+++ b/Source/GUIController.cs
@@ -143,11 +143,11 @@ namespace DebugMod
             }
 
             //Handle keybinds
-            foreach (KeyValuePair<string, int> bind in DebugMod.settings.binds)
+            foreach (KeyValuePair<string, KeyCode> bind in DebugMod.settings.binds)
             {
                 if (DebugMod.bindMethods.ContainsKey(bind.Key) || DebugMod.AdditionalBindMethods.ContainsKey(bind.Key) )
                 {
-                    if ((KeyCode) bind.Value == KeyCode.None)
+                    if (bind.Value == KeyCode.None)
                     {
                         foreach (KeyCode kc in Enum.GetValues(typeof(KeyCode)))
                         {
@@ -156,9 +156,9 @@ namespace DebugMod
                                 // Fix UX
                                 if (KeyBindPanel.keyWarning != kc)
                                 {
-                                    foreach (KeyValuePair<string, int> kvp in DebugMod.settings.binds)
+                                    foreach (KeyValuePair<string, KeyCode> kvp in DebugMod.settings.binds)
                                     {
-                                        if (kvp.Value == (int) kc)
+                                        if (kvp.Value == kc)
                                         {
                                             Console.AddLine(kc.ToString() + " already bound to " + kvp.Key +
                                                             ", press again to confirm");
@@ -179,7 +179,7 @@ namespace DebugMod
                                 }
                                 else if (kc != KeyCode.Escape)
                                 {
-                                    DebugMod.settings.binds[bind.Key] = (int) kc;
+                                    DebugMod.settings.binds[bind.Key] = kc;
                                 }
 
                                 KeyBindPanel.UpdateHelpText();
@@ -187,7 +187,7 @@ namespace DebugMod
                             }
                         }
                     }
-                    else if (Input.GetKeyDown((KeyCode) bind.Value))
+                    else if (Input.GetKeyDown(bind.Value))
                     {
                         //This makes sure atleast you can close the UI when the KeyBindLock is active.
                         //Im sure theres a better way to do this but idk. 

--- a/Source/KeyBindPanel.cs
+++ b/Source/KeyBindPanel.cs
@@ -200,11 +200,11 @@ namespace DebugMod
 
                 if (DebugMod.settings.binds.ContainsKey(bindStr))
                 {
-                    KeyCode code = ((KeyCode)DebugMod.settings.binds[bindStr]);
+                    KeyCode code = DebugMod.settings.binds[bindStr];
 
                     if (code != KeyCode.None)
                     {
-                        updatedText += ((KeyCode)DebugMod.settings.binds[bindStr]).ToString();
+                        updatedText += DebugMod.settings.binds[bindStr].ToString();
                     }
                     else
                     {
@@ -254,11 +254,11 @@ namespace DebugMod
 
             if (DebugMod.settings.binds.ContainsKey(bindName))
             {
-                DebugMod.settings.binds[bindName] = (int)KeyCode.None;
+                DebugMod.settings.binds[bindName] = KeyCode.None;
             }
             else
             {
-                DebugMod.settings.binds.Add(bindName, (int)KeyCode.None);
+                DebugMod.settings.binds.Add(bindName, KeyCode.None);
             }
 
             UpdateHelpText();

--- a/Source/SaveStates/SaveStateManager.cs
+++ b/Source/SaveStates/SaveStateManager.cs
@@ -151,9 +151,9 @@ namespace DebugMod
                     throw new ArgumentException("Helper func SelectSlot requires `bool` and `SaveStateType` to proceed the savestate process");
             }
 
-            if (DebugMod.settings.binds.TryGetValue(currentStateOperation, out int keycode))
+            if (DebugMod.settings.binds.TryGetValue(currentStateOperation, out KeyCode keycode))
             {
-                DebugMod.alphaKeyDict.Add((KeyCode)keycode, keycode);
+                DebugMod.alphaKeyDict.Add(keycode, (int)keycode);
             }
             else
             {

--- a/Source/Settings.cs
+++ b/Source/Settings.cs
@@ -1,8 +1,8 @@
 using System;
 using System.IO;
 using System.Collections.Generic;
-using Modding;
-
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
 using UnityEngine;
 
 namespace DebugMod
@@ -19,7 +19,8 @@ namespace DebugMod
     public class GlobalSettings
     {
         //Save members
-        public Dictionary<string, int> binds = new Dictionary<string, int>();
+        [JsonProperty(ItemConverterType = typeof(StringEnumConverter))]
+        public Dictionary<string, KeyCode> binds = new Dictionary<string, KeyCode>();
 
         public readonly string ModBaseDirectory = Path.Combine(Application.persistentDataPath, "DebugModData");
 


### PR DESCRIPTION
This does not break old gs files - ints and enum name strings are both correctly deserialized as the enum member names.