### PR TITLE
Presistent ToggleVignette and Improved Dupe Savestates (v2)

### DIFF
--- a/Source/BindableFunctions/Visual.cs
+++ b/Source/BindableFunctions/Visual.cs
@@ -14,7 +14,6 @@ using Modding;
 using Newtonsoft.Json;
 using UnityEngine;
 using Object = UnityEngine.Object;
-using SetSpriteRenderer = On.HutongGames.PlayMaker.Actions.SetSpriteRenderer;
 using USceneManager = UnityEngine.SceneManagement.SceneManager;
 
 namespace DebugMod

--- a/Source/BindableFunctions/Visual.cs
+++ b/Source/BindableFunctions/Visual.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
 using DebugMod.Hitbox;
+using DebugMod.MethodHelpers;
 using DebugMod.MonoBehaviours;
 using GlobalEnums;
 using HutongGames.PlayMaker;
@@ -75,46 +76,16 @@ namespace DebugMod
             Console.AddLine($"Shade Reach Showing {displaytext}");
         }
 
-        private static bool vignetteEnabled, vignetteOverridden = false;
-
         [BindableMethod(name = "Toggle Vignette", category = "Visual")]
         public static void ToggleVignette()
         {
-            bool newState = !HeroController.instance.vignette.enabled;
-            HeroController.instance.vignette.enabled = newState;
-            Console.AddLine("Vignette toggled " + (newState ? "On" : "Off"));
-            
-            if (!vignetteOverridden)
-            {
-                On.HeroController.SceneInit += CorrectVignetteState;
-                SetSpriteRenderer.OnEnter += CorrectVignetteFsm;
-                vignetteOverridden = true;
-                vignetteEnabled = newState;
-            }
-            else
-            {
-                On.HeroController.SceneInit -= CorrectVignetteState;
-                SetSpriteRenderer.OnEnter -= CorrectVignetteFsm;
-                vignetteOverridden = false;
-            }
-        }
-
-        private static void CorrectVignetteFsm(SetSpriteRenderer.orig_OnEnter orig, HutongGames.PlayMaker.Actions.SetSpriteRenderer self)
-        {
-            if (self.Fsm.Name != "Darkness Control" || self.Owner != HeroController.instance.vignette.gameObject)
-                orig(self);
-        }
-
-        private static void CorrectVignetteState(On.HeroController.orig_SceneInit orig, HeroController self)
-        {
-            orig(self);
-            self.vignette.enabled = vignetteEnabled;
+            VisualMaskHelper.ToggleVignette();
         }
 
         [BindableMethod(name = "Deactivate Visual Masks", category = "Visual")]
         public static void DoDeactivateVisualMasks()
         {
-            MethodHelpers.VisualMaskHelper.InvokedBindableFunction();
+            MethodHelpers.VisualMaskHelper.ToggleAllMasks();
         }
 
         [BindableMethod(name = "Toggle Hero Light", category = "Visual")]

--- a/Source/DebugMod.cs
+++ b/Source/DebugMod.cs
@@ -179,6 +179,7 @@ namespace DebugMod
 
             BossHandler.PopulateBossLists();
             GUIController.Instance.BuildMenus();
+            SceneWatcher.Init();
 
             KeyBindLock = false;
             TimeScaleActive = false;

--- a/Source/DebugMod.csproj
+++ b/Source/DebugMod.csproj
@@ -15,8 +15,8 @@
 
   <!-- Create a LocalBuildProperties.props file which defines HollowKnightFolder (references dir) 
   and OutputDirectory (where the post-build event sends the dll to) -->
-  <Import Project="LocalBuildProperties_example.props" Condition="Exists('LocalBuildProperties_example.props')"/>
-  <Import Project="LocalBuildProperties.props" Condition="Exists('LocalBuildProperties.props')"/>
+  <Import Project="LocalBuildProperties_example.props" Condition="Exists('LocalBuildProperties_example.props')" />
+  <Import Project="LocalBuildProperties.props" Condition="Exists('LocalBuildProperties.props')" />
   
  <ItemGroup>
      <None Remove="Images\**\*.png" />

--- a/Source/DebugMod.csproj
+++ b/Source/DebugMod.csproj
@@ -4,7 +4,7 @@
 
     <RootNamespace>DebugMod</RootNamespace>
     <AssemblyTitle>DebugMod</AssemblyTitle>
-    <AssemblyVersion>1.4.9.7</AssemblyVersion>
+    <AssemblyVersion>1.4.9.8</AssemblyVersion>
     <Deterministic>true</Deterministic>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <LangVersion>latest</LangVersion>

--- a/Source/LocalBuildProperties_example.props
+++ b/Source/LocalBuildProperties_example.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <HollowKnightFolder>C:\Program Files (x86)\Steam\steamapps\common\Hollow Knight\hollow_knight_Data\Managed</HollowKnightFolder>
-    <OutputDirectory>C:\Program Files (x86)\Steam\steamapps\common\Hollow Knight\hollow_knight_Data\Managed\Mods\</OutputDirectory>
+    <HollowKnightFolder>..\API</HollowKnightFolder>
+    <OutputDirectory>$(SolutionDir)</OutputDirectory>
   </PropertyGroup>
 </Project>

--- a/Source/LocalBuildProperties_example.props
+++ b/Source/LocalBuildProperties_example.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <HollowKnightFolder>..\API</HollowKnightFolder>
-    <OutputDirectory>$(SolutionDir)</OutputDirectory>
+    <HollowKnightFolder>C:\Program Files (x86)\Steam\steamapps\common\Hollow Knight\hollow_knight_Data\Managed</HollowKnightFolder>
+    <OutputDirectory>C:\Program Files (x86)\Steam\steamapps\common\Hollow Knight\hollow_knight_Data\Managed\Mods\</OutputDirectory>
   </PropertyGroup>
 </Project>

--- a/Source/MethodHelpers/VisualMaskHelper.cs
+++ b/Source/MethodHelpers/VisualMaskHelper.cs
@@ -23,11 +23,8 @@ namespace DebugMod.MethodHelpers
             else
             {
                 Console.AddLine("No longer disabling all visual masks; reload the room to see changes");
-                if (VignetteDisabled)
-                {
-                    Console.AddLine("Vignette was disabled; re-enabling");
-                    VignetteDisabled = false;
-                }
+                // Cannot reactivate most visual masks because it's impractical to find all that should be active;
+                // could reactivate the vignette, but do not for consistency.
             }
         }
 

--- a/Source/MethodHelpers/VisualMaskHelper.cs
+++ b/Source/MethodHelpers/VisualMaskHelper.cs
@@ -61,7 +61,9 @@ namespace DebugMod.MethodHelpers
             }
             
             if (VignetteDisabled)
+            {
                 DelayInvoke(3, () => DisableVignette(false));
+            }
         }
 
         public static void DelayInvoke(int delay, Action method)
@@ -69,7 +71,9 @@ namespace DebugMod.MethodHelpers
             IEnumerator coro()
             {
                 for (int i = 0; i < delay; i++)
+                {
                     yield return null;
+                }
                 method();
             }
             GameManager.instance.StartCoroutine(coro());
@@ -147,14 +151,17 @@ namespace DebugMod.MethodHelpers
         }
 
         /// <summary>
-        /// Disable the Vignette, as well as all of the renderers in its children
+        /// Disable the Vignette, as well as all renderers in its children.
         /// </summary>
-        public static void DisableVignette(bool thorough)
+        /// <param name="includeChildren">If this is false, do not disable renderer's in the vignette's children.</param>
+        public static void DisableVignette(bool includeChildren = true)
         {
             DebugMod.HC.vignette.enabled = false;
             
-            if (!thorough)
+            if (!includeChildren)
+            {
                 return;
+            }
             
             // Not suitable for toggle vignette because not easily reversible
             foreach (Renderer r in DebugMod.HC.vignette.GetComponentsInChildren<Renderer>())

--- a/Source/MethodHelpers/VisualMaskHelper.cs
+++ b/Source/MethodHelpers/VisualMaskHelper.cs
@@ -3,58 +3,73 @@ using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.SceneManagement;
+using Object = UnityEngine.Object;
 
 namespace DebugMod.MethodHelpers
 {
     public static class VisualMaskHelper
     {
-        private static bool DeactivatingOnSceneChange = false;
-        public static bool MasksDeactivated = false;
+        private static bool MasksDisabled = false;
+        private static bool VignetteDisabled = false;
 
-        public static void InvokedBindableFunction()
+        public static void ToggleAllMasks()
         {
-            if (!MasksDeactivated)
+            MasksDisabled = !MasksDisabled;
+            if (MasksDisabled)
             {
-                DeactivateVisualMasks(GameObject.FindObjectsOfType<GameObject>());
-                MasksDeactivated = true;
-                Console.AddLine("Press again to deactivate masks each scene change");
+                DeactivateVisualMasks(Object.FindObjectsOfType<GameObject>());
+                Console.AddLine("Disabled all visual masks");
             }
             else
             {
-                DeactivatingOnSceneChange = !DeactivatingOnSceneChange;
-                Console.AddLine((DeactivatingOnSceneChange ? "D" : "No longer d") + "eactivating visual masks each scene change");
+                Console.AddLine("No longer disabling all visual masks; reload the room to see changes");
+                if (VignetteDisabled)
+                {
+                    Console.AddLine("Vignette was disabled; re-enabling");
+                    VignetteDisabled = false;
+                }
+            }
+        }
+
+        public static void ToggleVignette()
+        {
+            VignetteDisabled = !VignetteDisabled;
+            if (VignetteDisabled)
+            {
+                DisableVignette(false);
+                Console.AddLine("Disabled vignette");
+            }
+            else
+            {
+                Console.AddLine("Enabled vignette");
+                DebugMod.HC.vignette.enabled = true;
+                if (MasksDisabled)
+                {
+                    Console.AddLine("All visual masks were disabled; re-enabling");
+                    MasksDisabled = false;
+                }
             }
         }
 
         public static void OnSceneChange(Scene s)
         {
-            if (DeactivatingOnSceneChange)
+            if (MasksDisabled)
             {
-                DelayInvoke(() => DeactivateVisualMasks(GetGameObjectsInScene(s)));
-                MasksDeactivated = true;
+                // Delaying for 2f seems enough - wait for 3 just to be sure though.
+                DelayInvoke(3, () => DeactivateVisualMasks(GetGameObjectsInScene(s)));
+                return;
             }
-            else
-            {
-                if (MasksDeactivated)
-                {
-                    // We need to reactivate the renderers attached to the vignette
-                    foreach (Renderer r in DebugMod.HC.vignette.GetComponentsInChildren<Renderer>(true))
-                    {
-                        r.enabled = true;
-                    }
-                }
-                MasksDeactivated = false;
-            }
+            
+            if (VignetteDisabled)
+                DelayInvoke(3, () => DisableVignette(false));
         }
 
-        public static void DelayInvoke(Action method)
+        public static void DelayInvoke(int delay, Action method)
         {
             IEnumerator coro()
             {
-                // Delaying for 2f seems enough - wait for 3 just to be sure though.
-                yield return null;
-                yield return null;
-                yield return null;
+                for (int i = 0; i < delay; i++)
+                    yield return null;
                 method();
             }
             GameManager.instance.StartCoroutine(coro());
@@ -126,7 +141,7 @@ namespace DebugMod.MethodHelpers
             Console.AddLine($"Deactivated {ctr} masks" + (HeroController.instance.vignette.enabled ? " and toggling vignette off" : string.Empty));
 
             // The vignette counts as a visual mask :)
-            ProperlyDisableVignette();
+            DisableVignette(true);
 
             return ctr;
         }
@@ -134,10 +149,14 @@ namespace DebugMod.MethodHelpers
         /// <summary>
         /// Disable the Vignette, as well as all of the renderers in its children
         /// </summary>
-        public static void ProperlyDisableVignette()
+        public static void DisableVignette(bool thorough)
         {
-            // Not suitable for toggle vignette because not easily reversible
             DebugMod.HC.vignette.enabled = false;
+            
+            if (!thorough)
+                return;
+            
+            // Not suitable for toggle vignette because not easily reversible
             foreach (Renderer r in DebugMod.HC.vignette.GetComponentsInChildren<Renderer>())
             {
                 r.enabled = false;

--- a/Source/SaveStates/SaveState.cs
+++ b/Source/SaveStates/SaveState.cs
@@ -59,10 +59,16 @@ namespace DebugMod
 
                 loadedSceneActiveScenes = new string[loadedScenes.Length];
                 if (_data.loadedSceneActiveScenes is not null)
+                {
                     Array.Copy(_data.loadedSceneActiveScenes, loadedSceneActiveScenes, loadedSceneActiveScenes.Length);
+                }
                 else
+                {
                     for (int i = 0; i < loadedScenes.Length; i++)
+                    {
                         loadedSceneActiveScenes[i] = loadedScenes[i];
+                    }
+                }
             }
         }
 
@@ -203,8 +209,10 @@ namespace DebugMod
 
             JsonUtility.FromJsonOverwrite(JsonUtility.ToJson(data.savedPd), PlayerData.instance);
 
-            var sceneData = data.loadedScenes.Zip(data.loadedSceneActiveScenes,
-                (name, gameplay) => new SceneWatcher.LoadedSceneInfo(name, gameplay)).ToArray();
+            SceneWatcher.LoadedSceneInfo[] sceneData = data
+                .loadedScenes
+                .Zip(data.loadedSceneActiveScenes, (name, gameplay) => new SceneWatcher.LoadedSceneInfo(name, gameplay))
+                .ToArray();
             
             sceneData[0].LoadHook();
 

--- a/Source/SaveStates/SaveState.cs
+++ b/Source/SaveStates/SaveState.cs
@@ -204,7 +204,7 @@ namespace DebugMod
             JsonUtility.FromJsonOverwrite(JsonUtility.ToJson(data.savedPd), PlayerData.instance);
 
             var sceneData = data.loadedScenes.Zip(data.loadedSceneActiveScenes,
-                (name, gameplay) => new SceneWatcher.SceneData(name, gameplay)).ToArray();
+                (name, gameplay) => new SceneWatcher.LoadedSceneInfo(name, gameplay)).ToArray();
             
             sceneData[0].LoadHook();
 
@@ -281,7 +281,7 @@ namespace DebugMod
             typeof(HeroController)
                 .GetMethod("FinishedEnteringScene", BindingFlags.NonPublic | BindingFlags.Instance)?
                 .Invoke(HeroController.instance, new object[] {true, false});
-            ReflectionHelper.CallMethod(GameManager.instance, "UpdateUIStateFromGameState", Array.Empty<object>());
+            ReflectionHelper.CallMethod(GameManager.instance, "UpdateUIStateFromGameState");
         }
         #endregion
 

--- a/Source/SaveStates/SaveState.cs
+++ b/Source/SaveStates/SaveState.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections;
 using System.IO;
+using System.Linq;
 using System.Reflection;
 using DebugMod.Hitbox;
 using GlobalEnums;
@@ -32,10 +33,10 @@ namespace DebugMod
             public string filePath;
             public bool isKinematized;
             public string[] loadedScenes;
+            public string[] loadedSceneActiveScenes;
 
             internal SaveStateData() { }
-            
-            
+
             internal SaveStateData(SaveStateData _data)
             {
                 saveStateIdentifier = _data.saveStateIdentifier;
@@ -51,6 +52,17 @@ namespace DebugMod
                     loadedScenes = new string[_data.loadedScenes.Length];
                     Array.Copy(_data.loadedScenes, loadedScenes, _data.loadedScenes.Length);
                 }
+                else
+                {
+                    loadedScenes = new[] { saveScene };
+                }
+
+                loadedSceneActiveScenes = new string[loadedScenes.Length];
+                if (_data.loadedSceneActiveScenes is not null)
+                    Array.Copy(_data.loadedSceneActiveScenes, loadedSceneActiveScenes, loadedSceneActiveScenes.Length);
+                else
+                    for (int i = 0; i < loadedScenes.Length; i++)
+                        loadedSceneActiveScenes[i] = loadedScenes[i];
             }
         }
 
@@ -74,12 +86,9 @@ namespace DebugMod
             data.cameraLockArea = (data.cameraLockArea ?? typeof(CameraController).GetField("currentLockArea", BindingFlags.Instance | BindingFlags.NonPublic));
             data.lockArea = data.cameraLockArea.GetValue(GameManager.instance.cameraCtrl);
             data.isKinematized = HeroController.instance.GetComponent<Rigidbody2D>().isKinematic;
-            int nLoadedScenes = USceneManager.sceneCount;
-            data.loadedScenes = new string[nLoadedScenes];
-            for (int i = 0; i < nLoadedScenes; i++)
-            {
-                data.loadedScenes[i] = USceneManager.GetSceneAt(i).name;
-            }
+            var scenes = SceneWatcher.LoadedScenes;
+            data.loadedScenes = scenes.Select(s => s.name).ToArray();
+            data.loadedSceneActiveScenes = scenes.Select(s => s.activeSceneWhenLoaded).ToArray();
         }
 
         public void NewSaveStateToFile(int paramSlot)
@@ -148,19 +157,7 @@ namespace DebugMod
                     SaveStateData tmpData = JsonUtility.FromJson<SaveStateData>(File.ReadAllText(data.filePath));
                     try
                     {
-                        data.saveStateIdentifier = tmpData.saveStateIdentifier;
-                        data.cameraLockArea = tmpData.cameraLockArea;
-                        data.savedPd = tmpData.savedPd;
-                        data.savedSd = tmpData.savedSd;
-                        data.savePos = tmpData.savePos;
-                        data.saveScene = tmpData.saveScene;
-                        data.lockArea = tmpData.lockArea;
-                        data.isKinematized = tmpData.isKinematized;
-                        if (tmpData.loadedScenes is not null)
-                        {
-                            data.loadedScenes = new string[tmpData.loadedScenes.Length];
-                            Array.Copy(tmpData.loadedScenes, data.loadedScenes, tmpData.loadedScenes.Length);
-                        }
+                        data = new SaveStateData(tmpData);
                         DebugMod.instance.Log("Load SaveState ready: " + data.saveStateIdentifier);
                     }
                     catch (Exception ex)
@@ -206,6 +203,11 @@ namespace DebugMod
 
             JsonUtility.FromJsonOverwrite(JsonUtility.ToJson(data.savedPd), PlayerData.instance);
 
+            var sceneData = data.loadedScenes.Zip(data.loadedSceneActiveScenes,
+                (name, gameplay) => new SceneWatcher.SceneData(name, gameplay)).ToArray();
+            
+            sceneData[0].LoadHook();
+
             GameManager.instance.BeginSceneTransition
             (
                 new DebugModSaveStateSceneLoadInfo
@@ -222,21 +224,25 @@ namespace DebugMod
             
             yield return new WaitUntil(() => USceneManager.GetActiveScene().name == data.saveScene);
             
-            if (loadDuped)
-            {
-                var GM = GameManager.instance;
-                for (int i = 1; i < data.loadedScenes.Length; i++)
-                {
-                    AsyncOperation loadop = USceneManager.LoadSceneAsync(data.loadedScenes[i], LoadSceneMode.Additive);
-                    loadop.allowSceneActivation = true;
-                    yield return loadop;
-                    GM.RefreshTilemapInfo(data.loadedScenes[i]);
-                }
-            }
+            GameManager.instance.cameraCtrl.PositionToHero(false);
 
             ReflectionHelper.SetField(GameManager.instance.cameraCtrl, "isGameplayScene", true);
             
-            GameManager.instance.cameraCtrl.PositionToHero(false);
+            if (loadDuped)
+            {
+                yield return new WaitUntil(() => GameManager.instance.IsInSceneTransition == false);
+                for (int i = 1; i < sceneData.Length; i++)
+                {
+                    On.GameManager.UpdateSceneName += sceneData[i].UpdateSceneNameOverride;
+                    AsyncOperation loadop = USceneManager.LoadSceneAsync(sceneData[i].name, LoadSceneMode.Additive);
+                    loadop.allowSceneActivation = true;
+                    yield return loadop;
+                    On.GameManager.UpdateSceneName -= sceneData[i].UpdateSceneNameOverride;
+                    GameManager.instance.RefreshTilemapInfo(sceneData[i].name);
+                    GameManager.instance.cameraCtrl.SceneInit();
+                }
+                GameManager.instance.BeginScene();
+            }
 
             if (data.lockArea != null)
             {
@@ -275,6 +281,7 @@ namespace DebugMod
             typeof(HeroController)
                 .GetMethod("FinishedEnteringScene", BindingFlags.NonPublic | BindingFlags.Instance)?
                 .Invoke(HeroController.instance, new object[] {true, false});
+            ReflectionHelper.CallMethod(GameManager.instance, "UpdateUIStateFromGameState", Array.Empty<object>());
         }
         #endregion
 

--- a/Source/SaveStates/SceneWatcher.cs
+++ b/Source/SaveStates/SceneWatcher.cs
@@ -1,0 +1,88 @@
+﻿using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using UnityEngine.SceneManagement;
+using Object = UnityEngine.Object;
+using USceneManager = UnityEngine.SceneManagement.SceneManager;
+
+namespace DebugMod
+{
+    public static class SceneWatcher
+    {
+        private static List<SceneData> scenes;
+        public static ReadOnlyCollection<SceneData> LoadedScenes => scenes.AsReadOnly();
+
+        private static Dictionary<Scene, int> scenesWithManager;
+
+        private static void AddScene(Scene scene, LoadSceneMode mode, bool checkSceneManager = true)
+        {
+            if (mode == LoadSceneMode.Single)
+                scenes.Clear();
+
+            SceneData d = new SceneData(scene.name, scene.name);
+            scenes.Add(d);
+
+            if (checkSceneManager && Object.FindObjectsOfType<SceneManager>().Any(m => m.gameObject.scene == scene))
+                scenesWithManager.Add(scene, d.id);
+        }
+
+        public static void Init()
+        {
+            scenesWithManager = new();
+            scenes = new();
+
+            for (int i = 0; i < USceneManager.sceneCount; i++)
+                AddScene(USceneManager.GetSceneAt(i), LoadSceneMode.Additive, false);
+            
+            USceneManager.sceneLoaded += (scene, mode) => AddScene(scene, mode);
+            On.SceneManager.Start += (orig, self) =>
+            {
+                orig(self);
+
+                if (!scenesWithManager.ContainsKey(self.gameObject.scene))
+                    return;
+
+                int id = scenesWithManager[self.gameObject.scene];
+                SceneData data = scenes.FirstOrDefault(d => d.id == id);
+                scenesWithManager.Remove(self.gameObject.scene);
+                
+                if (data != null)
+                    data.activeSceneWhenLoaded = GameManager.instance.sceneName;
+            };
+            USceneManager.sceneUnloaded += s => scenes.RemoveAt(scenes.FindIndex(d => d.name == s.name));
+        }
+        
+        public class SceneData
+        {
+            private static int counter = 0;
+            
+            public readonly string name;
+            public string activeSceneWhenLoaded { get; internal set; }
+            public readonly int id;
+
+            public SceneData(string name, string activeSceneName)
+            {
+                this.name = name;
+                this.id = counter++;
+                this.activeSceneWhenLoaded = activeSceneName;
+            }
+
+            public void LoadHook()
+            {
+                On.GameManager.UpdateSceneName += UpdateSceneNameOverride;
+                GameManager.instance.OnFinishedSceneTransition += FinishedSceneTransitionHook;
+            }
+
+            private void FinishedSceneTransitionHook()
+            {
+                GameManager.instance.OnFinishedSceneTransition -= FinishedSceneTransitionHook;
+                On.GameManager.UpdateSceneName -= UpdateSceneNameOverride;
+            }
+
+            public void UpdateSceneNameOverride(On.GameManager.orig_UpdateSceneName orig, GameManager self)
+            {
+                self.sceneName = activeSceneWhenLoaded;
+            }
+        }
+    }
+}

--- a/Source/SaveStates/SceneWatcher.cs
+++ b/Source/SaveStates/SceneWatcher.cs
@@ -9,8 +9,8 @@ namespace DebugMod
 {
     public static class SceneWatcher
     {
-        private static List<SceneData> scenes;
-        public static ReadOnlyCollection<SceneData> LoadedScenes => scenes.AsReadOnly();
+        private static List<LoadedSceneInfo> scenes;
+        public static ReadOnlyCollection<LoadedSceneInfo> LoadedScenes => scenes.AsReadOnly();
 
         private static Dictionary<Scene, int> scenesWithManager;
 
@@ -19,7 +19,7 @@ namespace DebugMod
             if (mode == LoadSceneMode.Single)
                 scenes.Clear();
 
-            SceneData d = new SceneData(scene.name, scene.name);
+            LoadedSceneInfo d = new LoadedSceneInfo(scene.name, scene.name);
             scenes.Add(d);
 
             if (checkSceneManager && Object.FindObjectsOfType<SceneManager>().Any(m => m.gameObject.scene == scene))
@@ -43,16 +43,16 @@ namespace DebugMod
                     return;
 
                 int id = scenesWithManager[self.gameObject.scene];
-                SceneData data = scenes.FirstOrDefault(d => d.id == id);
+                LoadedSceneInfo lsi = scenes.FirstOrDefault(i => i.id == id);
                 scenesWithManager.Remove(self.gameObject.scene);
                 
-                if (data != null)
-                    data.activeSceneWhenLoaded = GameManager.instance.sceneName;
+                if (lsi != null)
+                    lsi.activeSceneWhenLoaded = GameManager.instance.sceneName;
             };
             USceneManager.sceneUnloaded += s => scenes.RemoveAt(scenes.FindIndex(d => d.name == s.name));
         }
         
-        public class SceneData
+        public class LoadedSceneInfo
         {
             private static int counter = 0;
             
@@ -60,7 +60,7 @@ namespace DebugMod
             public string activeSceneWhenLoaded { get; internal set; }
             public readonly int id;
 
-            public SceneData(string name, string activeSceneName)
+            public LoadedSceneInfo(string name, string activeSceneName)
             {
                 this.name = name;
                 this.id = counter++;


### PR DESCRIPTION
Continues #24, had to restart pr due to merge

Changes:
- Renamed `SceneWatcher.SceneData` to `SceneWatcher.LoadedSceneInfo`
- Changed implementation of `ToggleVignette` to match `DeactivateVisualMasks`
- Changed `DeactivateVisualMasks` to persist state until button is pressed again